### PR TITLE
Fix child management forms and details

### DIFF
--- a/resources/views/children/create.blade.php
+++ b/resources/views/children/create.blade.php
@@ -43,8 +43,9 @@
             </div>
 
             <div class="col-12 form-check form-switch mt-2">
+                <input type="hidden" name="is_active" value="0">
                 <input class="form-check-input" type="checkbox" role="switch" id="is_active"
-                       name="is_active" value="1" {{ old('is_active',1) ? 'checked' : '' }}>
+                       name="is_active" value="1" @checked(old('is_active', 1))>
                 <label class="form-check-label" for="is_active">Активен</label>
             </div>
         </div>

--- a/resources/views/children/edit.blade.php
+++ b/resources/views/children/edit.blade.php
@@ -6,30 +6,49 @@
         @csrf
         @method('PUT')
         <div class="row g-3">
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <label class="form-label">Фамилия</label>
                 <input name="last_name" class="form-control"
                        value="{{ old('last_name', $child->last_name) }}" required>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <label class="form-label">Имя</label>
                 <input name="first_name" class="form-control"
                        value="{{ old('first_name', $child->first_name) }}" required>
             </div>
             <div class="col-md-4">
+                <label class="form-label">Отчество</label>
+                <input name="patronymic" class="form-control"
+                       value="{{ old('patronymic', $child->patronymic) }}">
+            </div>
+
+            <div class="col-md-4">
                 <label class="form-label">Дата рождения</label>
                 <input type="date" name="dob" class="form-control"
                        value="{{ old('dob', optional($child->dob)->format('Y-m-d')) }}">
+            </div>
+
+            <div class="col-md-4">
+                <label class="form-label">Телефон ребёнка</label>
+                <input name="child_phone" class="form-control"
+                       value="{{ old('child_phone', $child->child_phone) }}">
             </div>
             <div class="col-md-4">
                 <label class="form-label">Телефон родителя</label>
                 <input name="parent_phone" class="form-control"
                        value="{{ old('parent_phone', $child->parent_phone) }}">
             </div>
+            <div class="col-md-4">
+                <label class="form-label">Телефон второго родителя</label>
+                <input name="parent2_phone" class="form-control"
+                       value="{{ old('parent2_phone', $child->parent2_phone) }}">
+            </div>
+
             <div class="col-12">
                 <label class="form-label">Заметки</label>
                 <textarea name="notes" rows="3" class="form-control">{{ old('notes', $child->notes) }}</textarea>
             </div>
+
         </div>
         <div class="mt-3 d-flex gap-2">
             <button class="btn btn-primary">Сохранить</button>

--- a/resources/views/children/index.blade.php
+++ b/resources/views/children/index.blade.php
@@ -20,15 +20,25 @@
                 <thead class="table-light">
                 <tr>
                     <th>ФИО</th>
-                    <th>Телефон</th>
-                    <th></th>
+                    <th>Телефон(ы)</th>
+                    <th class="text-end">Действия</th>
                 </tr>
                 </thead>
                 <tbody>
                 @forelse($children as $c)
                     <tr>
-                        <td><a href="{{ route('children.show',$c) }}" class="link-body-emphasis">{{ $c->last_name }} {{ $c->first_name }}</a></td>
-                        <td>{{ $c->parent_phone }}</td>
+                        <td>
+                            <a href="{{ route('children.show',$c) }}" class="link-body-emphasis">{{ $c->full_name }}</a>
+                            @unless($c->is_active)
+                                <span class="badge text-bg-secondary ms-1">неактивен</span>
+                            @endunless
+                        </td>
+                        <td>
+                            <div>{{ $c->parent_phone ?? $c->child_phone ?? '—' }}</div>
+                            @if($c->parent2_phone)
+                                <div class="text-secondary small">{{ $c->parent2_phone }}</div>
+                            @endif
+                        </td>
                         <td class="text-end">
                             <a href="{{ route('children.edit',$c) }}" class="btn btn-sm btn-outline-secondary">Править</a>
                         </td>

--- a/resources/views/children/show.blade.php
+++ b/resources/views/children/show.blade.php
@@ -42,12 +42,96 @@
         <a href="{{ route('children.index') }}" class="btn btn-link">Назад к списку</a>
     </div>
 
-    {{-- Блоки для расширения в будущем --}}
     <div class="mt-4">
-        <h2 class="h5 mb-3">Прикрепления и посещения</h2>
+        <h2 class="h5 mb-3">Прикрепления</h2>
         <div class="card">
-            <div class="card-body">
-                <p class="text-secondary mb-0">Здесь позже можно вывести список секций, пакетов и историю посещений ребёнка.</p>
+            <div class="table-responsive">
+                <table class="table table-striped align-middle mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>Секция</th>
+                        <th>Пакет</th>
+                        <th>Период</th>
+                        <th>Остаток</th>
+                        <th>Статус</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @forelse($child->enrollments as $enrollment)
+                        @php
+                            $periodStart = $enrollment->started_at?->format('d.m.Y');
+                            $periodEnd = $enrollment->expires_at?->format('d.m.Y');
+                            $period = $periodStart ?? '—';
+                            if ($periodEnd) {
+                                $period .= ' — ' . $periodEnd;
+                            }
+                            $visitsLeft = $enrollment->visits_left !== null ? $enrollment->visits_left : '—';
+                            $statusMap = [
+                                'pending' => 'Ожидает оплаты',
+                                'partial' => 'Частично оплачен',
+                                'paid' => 'Оплачен',
+                                'expired' => 'Истёк',
+                            ];
+                        @endphp
+                        <tr>
+                            <td>{{ $enrollment->section?->name ?? '—' }}</td>
+                            <td>
+                                {{ $enrollment->package?->name ?? '—' }}
+                                @if($enrollment->package?->section && $enrollment->package->section_id !== $enrollment->section_id)
+                                    <span class="badge text-bg-warning ms-1">другая секция</span>
+                                @endif
+                            </td>
+                            <td>{{ $period }}</td>
+                            <td>{{ $visitsLeft }}</td>
+                            <td>{{ $statusMap[$enrollment->status] ?? $enrollment->status }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="text-center text-secondary py-4">Прикреплений пока нет</td>
+                        </tr>
+                    @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        <h2 class="h5 mb-3">Платежи</h2>
+        <div class="card">
+            <div class="table-responsive">
+                <table class="table table-striped align-middle mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>Дата</th>
+                        <th>Секция</th>
+                        <th>Пакет</th>
+                        <th>Сумма</th>
+                        <th>Комментарий</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @forelse($child->payments as $payment)
+                        <tr>
+                            <td>{{ $payment->paid_at?->format('d.m.Y H:i') ?? '—' }}</td>
+                            <td>{{ $payment->enrollment?->section?->name ?? '—' }}</td>
+                            <td>{{ $payment->enrollment?->package?->name ?? '—' }}</td>
+                            <td>
+                                @if($payment->amount !== null)
+                                    {{ number_format((float) $payment->amount, 2, ',', ' ') }} ₽
+                                @else
+                                    —
+                                @endif
+                            </td>
+                            <td>{{ $payment->comment ?? '—' }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="text-center text-secondary py-4">Платежей ещё не было</td>
+                        </tr>
+                    @endforelse
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- validate and persist full child profile data when creating or editing records
- enhance children listings and detail pages with relationship-aware information and statuses
- load related enrollments and payments efficiently while removing invalid package ordering

## Testing
- php artisan test *(fails: missing vendor dependencies; composer install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ffdeb51c83269178981d91bc8f7a