### PR TITLE
Добавить шаблоны управления комнатами

### DIFF
--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -1,31 +1,65 @@
 <?php
+
 namespace App\Http\Controllers;
+
 use App\Models\Room;
 use Illuminate\Http\Request;
 
-
 class RoomController extends Controller
 {
-    public function index(){ $rooms = Room::orderBy('name')->paginate(20); return view('rooms.index', compact('rooms')); }
-    public function create(){ return view('rooms.create'); }
-    public function store(Request $request){
-        $data = $request->validate([
-            'name'=>['required','string','max:150'],
-            'number_label'=>['nullable','string','max:50'],
-            'capacity'=>['nullable','integer','min:1'],
-            'spec'=>['nullable','string']
-        ]);
-        Room::create($data); return redirect()->route('rooms.index')->with('success','Комната создана');
+    public function index()
+    {
+        $rooms = Room::query()->orderBy('name')->paginate(20);
+
+        return view('rooms.index', compact('rooms'));
     }
-    public function edit(Room $room){ return view('rooms.edit', compact('room')); }
-    public function update(Request $request, Room $room){
-        $data = $request->validate([
-            'name'=>['required','string','max:150'],
-            'number_label'=>['nullable','string','max:50'],
-            'capacity'=>['nullable','integer','min:1'],
-            'spec'=>['nullable','string']
-        ]);
-        $room->update($data); return redirect()->route('rooms.index')->with('success','Обновлено');
+
+    public function create()
+    {
+        return view('rooms.create');
     }
-    public function destroy(Room $room){ $room->delete(); return back()->with('success','Удалено'); }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:150'],
+            'number_label' => ['nullable', 'string', 'max:50'],
+            'capacity' => ['nullable', 'integer', 'min:1'],
+            'spec' => ['nullable', 'string'],
+        ]);
+
+        Room::create($data);
+
+        return redirect()
+            ->route('rooms.index')
+            ->with('success', 'Комната создана');
+    }
+
+    public function edit(Room $room)
+    {
+        return view('rooms.edit', compact('room'));
+    }
+
+    public function update(Request $request, Room $room)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:150'],
+            'number_label' => ['nullable', 'string', 'max:50'],
+            'capacity' => ['nullable', 'integer', 'min:1'],
+            'spec' => ['nullable', 'string'],
+        ]);
+
+        $room->update($data);
+
+        return redirect()
+            ->route('rooms.index')
+            ->with('success', 'Обновлено');
+    }
+
+    public function destroy(Room $room)
+    {
+        $room->delete();
+
+        return back()->with('success', 'Удалено');
+    }
 }

--- a/resources/views/rooms/create.blade.php
+++ b/resources/views/rooms/create.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1 class="h4 mb-3">Добавить комнату</h1>
+
+    <form method="POST" action="{{ route('rooms.store') }}" class="card card-body">
+        @csrf
+        <div class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Название<span class="text-danger">*</span></label>
+                <input name="name" class="form-control" value="{{ old('name') }}" required>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Номер</label>
+                <input name="number_label" class="form-control" value="{{ old('number_label') }}">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Вместимость</label>
+                <input type="number" min="1" name="capacity" class="form-control" value="{{ old('capacity') }}">
+            </div>
+            <div class="col-12">
+                <label class="form-label">Спецификация</label>
+                <textarea name="spec" rows="4" class="form-control">{{ old('spec') }}</textarea>
+            </div>
+        </div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-primary">Сохранить</button>
+            <a href="{{ route('rooms.index') }}" class="btn btn-link">Отмена</a>
+        </div>
+    </form>
+@endsection

--- a/resources/views/rooms/edit.blade.php
+++ b/resources/views/rooms/edit.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1 class="h4 mb-3">Редактировать комнату</h1>
+
+    <form method="POST" action="{{ route('rooms.update', $room) }}" class="card card-body">
+        @csrf
+        @method('PUT')
+        <div class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Название<span class="text-danger">*</span></label>
+                <input name="name" class="form-control" value="{{ old('name', $room->name) }}" required>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Номер</label>
+                <input name="number_label" class="form-control" value="{{ old('number_label', $room->number_label) }}">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Вместимость</label>
+                <input type="number" min="1" name="capacity" class="form-control"
+                       value="{{ old('capacity', $room->capacity) }}">
+            </div>
+            <div class="col-12">
+                <label class="form-label">Спецификация</label>
+                <textarea name="spec" rows="4" class="form-control">{{ old('spec', $room->spec) }}</textarea>
+            </div>
+        </div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-primary">Сохранить</button>
+            <a href="{{ route('rooms.index') }}" class="btn btn-link">Отмена</a>
+        </div>
+    </form>
+@endsection

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -1,29 +1,47 @@
 @extends('layouts.app')
+
 @section('content')
     <div class="d-flex justify-content-between mb-3">
         <h1 class="h4">Комнаты</h1>
         <a href="{{ route('rooms.create') }}" class="btn btn-primary">Добавить</a>
     </div>
-    <div class="card"><div class="table-responsive">
+    <div class="card">
+        <div class="table-responsive">
             <table class="table table-striped mb-0">
-                <thead class="table-light"><tr><th>Название</th><th>№</th><th>Вместимость</th><th>Спецификация</th><th></th></tr></thead>
+                <thead class="table-light">
+                    <tr>
+                        <th>Название</th>
+                        <th>№</th>
+                        <th>Вместимость</th>
+                        <th>Спецификация</th>
+                        <th></th>
+                    </tr>
+                </thead>
                 <tbody>
-                @foreach($rooms as $r)
+                @forelse($rooms as $r)
                     <tr>
                         <td>{{ $r->name }}</td>
                         <td>{{ $r->number_label }}</td>
                         <td>{{ $r->capacity }}</td>
-                        <td class="text-truncate" style="max-width:300px">{{ $r->spec }}</td>
+                        <td class="text-truncate" style="max-width: 300px">{{ $r->spec }}</td>
                         <td class="text-end">
-                            <a class="btn btn-sm btn-outline-secondary" href="{{ route('rooms.edit',$r) }}">Править</a>
-                            <form class="d-inline" method="POST" action="{{ route('rooms.destroy',$r) }}" onsubmit="return confirm('Удалить комнату?')">@csrf @method('DELETE')
+                            <a class="btn btn-sm btn-outline-secondary" href="{{ route('rooms.edit', $r) }}">Править</a>
+                            <form class="d-inline" method="POST" action="{{ route('rooms.destroy', $r) }}"
+                                  onsubmit="return confirm('Удалить комнату?')">
+                                @csrf
+                                @method('DELETE')
                                 <button class="btn btn-sm btn-outline-danger">Удалить</button>
                             </form>
                         </td>
                     </tr>
-                @endforeach
+                @empty
+                    <tr>
+                        <td colspan="5" class="text-center text-muted py-4">Комнаты ещё не добавлены</td>
+                    </tr>
+                @endforelse
                 </tbody>
             </table>
-        </div></div>
+        </div>
+    </div>
     <div class="mt-3">{{ $rooms->links() }}</div>
 @endsection


### PR DESCRIPTION
## Summary
- добавить форму создания комнаты с полями названия, номера, вместимости и описания
- создать шаблон редактирования комнаты с предзаполненными данными
- улучшить таблицу списка комнат и отформатировать RoomController по PSR-12

## Testing
- php artisan test *(fails: отсутствует vendor, composer install требует авторизации GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c7ad0c208326a70fb8ae9ae1d492