### PR TITLE
Revamp reception shift workflow

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,17 +30,13 @@
                 <li class="nav-item"><a class="nav-link" href="/users">Пользователи</a></li>
                 @endrole
             </ul>
-            <form class="d-flex gap-2" method="POST" action="{{ route('shift.start') }}">@csrf
-                <button class="btn btn-success btn-sm">Начать смену</button>
-            </form>
-            <form class="ms-2" method="POST" action="{{ route('shift.stop') }}">@csrf
-                <button class="btn btn-secondary btn-sm">Завершить</button>
-            </form>
-            <div class="ms-3 small"><a class="nav-link" href="/account">Личный кабинет {{ auth()->user()->name ?? '' }}</a></div>
-            <form method="POST" action="{{ route('logout') }}" class="ms-2">
-                @csrf
-                <button type="submit" class="btn btn-link nav-link px-0">Выйти</button>
-            </form>
+            <div class="d-flex align-items-center gap-3 ms-lg-auto">
+                <a class="nav-link" href="/account">Личный кабинет {{ auth()->user()->name ?? '' }}</a>
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit" class="btn btn-link nav-link px-0">Выйти</button>
+                </form>
+            </div>
         </div>
     </div>
 </nav>
@@ -49,5 +45,6 @@
     @yield('content')
 </main>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+@stack('scripts')
 </body>
 </html>

--- a/resources/views/reception/index.blade.php
+++ b/resources/views/reception/index.blade.php
@@ -1,77 +1,267 @@
 @extends('layouts.app')
 
+@section('content')
+<div class="d-flex flex-column gap-4">
+    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-end">
+        <div>
+            <h1 class="h3 mb-1">Ресепшен</h1>
+            <p class="text-secondary mb-0">Управляйте сменой и отмечайте детей, которые пришли на занятия сегодня.</p>
+        </div>
+        <form class="ms-lg-auto w-100 w-lg-auto" method="GET" action="{{ route('reception.index') }}">
+            <div class="input-group">
+                <input type="search" name="q" value="{{ $q }}" class="form-control" placeholder="Поиск ребёнка или телефона">
+                <button class="btn btn-primary" type="submit">Поиск</button>
+                @if($q !== '')
+                    <a class="btn btn-outline-secondary" href="{{ route('reception.index') }}">Сбросить</a>
+                @endif
+            </div>
+        </form>
+    </div>
 
-@foreach($sections as $s)
-    <div class="card mb-4">
-        <div class="card-body">
-            <div class="d-flex justify-content-between flex-wrap gap-2 align-items-start">
-                <div>
-                    <div class="h5 mb-1">{{ $s->name }} @if($s->parent) <span class="text-secondary">→ {{ $s->parent->name }}</span> @endif</div>
-                    <div class="small text-secondary">
-                        Комната: {{ $s->room? ($s->room->name.' ('.$s->room->number_label.')') : '—' }}
-                        · Тип расписания: {{ $s->schedule_type==='weekly'?'по дням недели':'по дням месяца' }}
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <div class="row g-4 align-items-center">
+                <div class="col-lg-7">
+                    <h2 class="h4 mb-3">Управление сменой</h2>
+                    @if($shift)
+                        <div class="d-flex flex-column gap-2">
+                            <div class="text-success fw-semibold">Смена активна с {{ $shift->started_at->format('d.m.Y H:i') }}</div>
+                            <div class="small text-secondary">Прошло времени: <span class="fw-semibold" data-shift-timer data-start="{{ $shift->started_at->toIso8601String() }}">{{ $shiftElapsed }}</span></div>
+                            <p class="text-secondary mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer cursus malesuada est, eget efficitur odio hendrerit id.</p>
+                        </div>
+                    @else
+                        <p class="text-secondary mb-0">Смена ещё не начата. Нажмите «Начать смену», чтобы зафиксировать старт рабочего дня.</p>
+                    @endif
+                </div>
+                <div class="col-lg-5">
+                    <div class="d-flex flex-column flex-sm-row justify-content-end gap-3">
+                        <form method="POST" action="{{ route('shift.start') }}" class="flex-fill">
+                            @csrf
+                            <button type="submit" class="btn btn-success btn-lg w-100" {{ $shift ? 'disabled' : '' }}>Начать смену</button>
+                        </form>
+                        <form method="POST" action="{{ route('shift.stop') }}" class="flex-fill">
+                            @csrf
+                            <button type="submit" class="btn btn-outline-secondary btn-lg w-100" {{ $shift ? '' : 'disabled' }}>Завершить смену</button>
+                        </form>
                     </div>
                 </div>
             </div>
-
-
-            @php
-                // Для разработки: соберём список детей по прикреплениям
-                $enrs = \App\Models\Enrollment::with('child')
-                ->where('section_id',$s->id)
-                ->whereHas('child', fn($q)=>$q->where('is_active',true))
-                ->orderByDesc('started_at');
-                $page = request()->integer('p_'.$s->id, 1);
-                $per = 10;
-                $total = (clone $enrs)->count();
-                $items = (clone $enrs)->skip(($page-1)*$per)->take($per)->get();
-            @endphp
-
-
-            <div class="mt-3">
-                @foreach($items as $e)
-                    @php
-                        $child = $e->child; if(!$child) continue;
-                        $today = now()->toDateString();
-                        $already = \App\Models\Attendance::where('child_id',$child->id)->where('section_id',$s->id)->where('attended_on',$today)->exists();
-                    @endphp
-                    <form class="d-flex justify-content-between align-items-center border rounded p-2 mb-2" method="POST" action="{{ route('reception.mark') }}">
-                        @csrf
-                        <div>
-                            <div class="fw-semibold">{{ $child->full_name }}</div>
-                            <div class="small text-secondary">
-                                Пакет: {{ $e->package->name }}
-                                @if($e->package->billing_type === 'visits' && $e->package->visits_count)
-                                    · {{ $e->package->visits_count }} занятий
-                                @elseif($e->package->billing_type === 'period' && $e->package->days)
-                                    · {{ $e->package->days }} дн.
-                                @endif
-                                @if($e->visits_left!==null)
-                                    — осталось {{ $e->visits_left }}
-                                @else
-                                    — до {{ optional($e->expires_at)->format('d.m.Y') }}
-                                @endif
-                            </div>
-                        </div>
-                        <input type="hidden" name="child_id" value="{{ $child->id }}">
-                        <input type="hidden" name="section_id" value="{{ $s->id }}">
-                        <button class="btn btn-sm {{ $already ? 'btn-outline-secondary' : 'btn-primary' }}" {{ $already ? 'disabled' : '' }}>
-                            {{ $already ? 'Уже отмечен' : 'Пришёл' }}
-                        </button>
-                    </form>
-                @endforeach
-
-
-                {{-- пагинация по 10 строк на секцию (простейшая) --}}
-                @if($total>$per)
-                    <div class="d-flex gap-2">
-                        @for($i=1;$i<=ceil($total/$per);$i++)
-                            <a class="btn btn-sm {{ $i==$page? 'btn-primary' : 'btn-outline-primary' }}" href="?p_{{ $s->id }}={{ $i }}#sec{{ $s->id }}">{{ $i }}</a>
-                        @endfor
-                    </div>
-                @endif
-            </div>
         </div>
     </div>
-@endforeach
+
+    @if($q !== '' && $sectionCards->sum('total') === 0)
+        <div class="alert alert-warning mb-0">По запросу «{{ $q }}» ничего не найдено.</div>
+    @endif
+
+    @forelse($sectionCards as $card)
+        @php
+            /** @var \App\Models\Section $section */
+            $section = $card['section'];
+            $enrollments = $card['enrollments'];
+            $attendedToday = $card['attended_today'];
+        @endphp
+        <div class="card shadow-sm border-0" id="sec{{ $section->id }}">
+            <div class="card-body p-4">
+                <div class="d-flex flex-column flex-md-row justify-content-between gap-3 align-items-start">
+                    <div>
+                        <div class="h5 mb-1">{{ $section->name }} @if($section->parent) <span class="text-secondary">→ {{ $section->parent->name }}</span> @endif</div>
+                        @php
+                            $roomLabel = $section->room?->name;
+                            if ($section->room?->number_label) {
+                                $roomLabel .= ' ('.$section->room->number_label.')';
+                            }
+                        @endphp
+                        <div class="small text-secondary">Комната: {{ $section->room ? $roomLabel : '—' }}</div>
+                        <div class="small text-secondary">Тип расписания: {{ $section->schedule_type==='weekly' ? 'по дням недели' : 'по дням месяца' }}</div>
+                    </div>
+                    <div class="text-secondary small">Всего детей сегодня: {{ $card['total'] }}</div>
+                </div>
+
+                <div class="mt-4">
+                    @forelse($enrollments as $enrollment)
+                        @php
+                            $child = $enrollment->child;
+                            if(!$child) { continue; }
+                            $already = in_array($child->id, $attendedToday, true);
+                            $package = $enrollment->package;
+                            $status = $enrollment->status ?? 'pending';
+                            $needsPayment = $status !== 'paid';
+                            $price = $enrollment->price ?? ($package->price ?? null);
+                            $statusLabels = [
+                                'paid' => 'Оплачено',
+                                'partial' => 'Оплачено частично',
+                                'pending' => 'Не оплачено',
+                                'expired' => 'Срок истёк',
+                            ];
+                            $statusClasses = [
+                                'paid' => 'badge bg-success-subtle text-success-emphasis',
+                                'partial' => 'badge bg-warning-subtle text-warning-emphasis',
+                                'pending' => 'badge bg-danger-subtle text-danger-emphasis',
+                                'expired' => 'badge bg-secondary-subtle text-secondary-emphasis',
+                            ];
+                            $statusLabel = $statusLabels[$status] ?? 'Статус неизвестен';
+                            $statusClass = $statusClasses[$status] ?? 'badge bg-secondary';
+                            $modalId = 'payment-modal-'.$enrollment->id;
+                            $inputId = 'payment-amount-'.$enrollment->id;
+                        @endphp
+                        <div class="border rounded-3 p-3 mb-3 bg-light">
+                            <div class="row align-items-center g-3">
+                                <div class="col-md">
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+                                        <div class="fw-semibold">{{ $child->full_name }}</div>
+                                        <span class="{{ $statusClass }}">{{ $statusLabel }}</span>
+                                        @if($status === 'pending')
+                                            <span class="small text-danger">Не оплачено</span>
+                                        @endif
+                                    </div>
+                                    <div class="text-secondary small">
+                                        Пакет: {{ $package?->name ?? '—' }}
+                                        @if($package?->billing_type === 'visits' && $package?->visits_count)
+                                            · {{ $package->visits_count }} занятий
+                                        @elseif($package?->billing_type === 'period' && $package?->days)
+                                            · {{ $package->days }} дн.
+                                        @endif
+                                        @if(!is_null($enrollment->visits_left))
+                                            — осталось {{ $enrollment->visits_left }}
+                                        @else
+                                            — до {{ optional($enrollment->expires_at)->format('d.m.Y') ?? '∞' }}
+                                        @endif
+                                    </div>
+                                    <div class="text-secondary small mt-1">
+                                        Оплачено: {{ number_format((float)($enrollment->total_paid ?? 0), 2, ',', ' ') }} ₽
+                                        @if($price)
+                                            из {{ number_format((float)$price, 2, ',', ' ') }} ₽
+                                        @endif
+                                    </div>
+                                </div>
+                                <div class="col-md-auto d-flex flex-wrap gap-2">
+                                    <form class="d-inline" method="POST" action="{{ route('reception.mark') }}" data-attendance-form>
+                                        @csrf
+                                        <input type="hidden" name="child_id" value="{{ $child->id }}">
+                                        <input type="hidden" name="section_id" value="{{ $section->id }}">
+                                        <button class="btn btn-primary" type="submit" {{ $already ? 'disabled' : '' }}>
+                                            {{ $already ? 'Уже отмечен' : 'Пришёл' }}
+                                        </button>
+                                    </form>
+                                    @if($needsPayment)
+                                        <button class="btn btn-outline-warning" type="button" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}">Оплатить</button>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+
+                        @if($needsPayment)
+                            <div class="modal fade" id="{{ $modalId }}" tabindex="-1" aria-hidden="true">
+                                <div class="modal-dialog modal-dialog-centered">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title">Оплата занятия</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <form method="POST" action="{{ route('payments.store') }}">
+                                            @csrf
+                                            <input type="hidden" name="enrollment_id" value="{{ $enrollment->id }}">
+                                            <div class="modal-body">
+                                                <dl class="row mb-4">
+                                                    <dt class="col-sm-4">Ребёнок</dt>
+                                                    <dd class="col-sm-8 mb-2">{{ $child->full_name }}</dd>
+                                                    <dt class="col-sm-4">Секция</dt>
+                                                    <dd class="col-sm-8 mb-2">{{ $section->name }}</dd>
+                                                    <dt class="col-sm-4">Пакет</dt>
+                                                    <dd class="col-sm-8 mb-0">{{ $package?->name ?? '—' }}</dd>
+                                                </dl>
+                                                <div class="mb-3">
+                                                    <label for="{{ $inputId }}" class="form-label">Сумма оплаты</label>
+                                                    <div class="input-group">
+                                                        <input type="number" class="form-control" step="0.01" min="0" name="amount" id="{{ $inputId }}" placeholder="0.00" required>
+                                                        <button class="btn btn-outline-primary" type="button" data-fill-amount data-target="{{ $inputId }}" data-amount="{{ $price ?? 0 }}">Оплатить</button>
+                                                    </div>
+                                                    @if($price)
+                                                        <div class="form-text">Стоимость пакета: {{ number_format((float)$price, 2, ',', ' ') }} ₽</div>
+                                                    @endif
+                                                </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Отмена</button>
+                                                <button type="submit" class="btn btn-primary">Сохранить</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        @endif
+                    @empty
+                        <div class="text-center text-secondary py-4">Нет прикреплённых детей на сегодня.</div>
+                    @endforelse
+
+                    @if($card['total'] > $card['per_page'])
+                        @php
+                            $pages = (int) ceil($card['total'] / $card['per_page']);
+                            $currentQuery = request()->query();
+                        @endphp
+                        <div class="d-flex flex-wrap gap-2 mt-3">
+                            @for($i = 1; $i <= $pages; $i++)
+                                @php
+                                    $query = array_merge($currentQuery, ['p_'.$section->id => $i]);
+                                    $url = route('reception.index', $query) . '#sec' . $section->id;
+                                @endphp
+                                <a class="btn btn-sm {{ $i === $card['page'] ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ $url }}">{{ $i }}</a>
+                            @endfor
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @empty
+        <div class="alert alert-info mb-0">На сегодня нет активных секций.</div>
+    @endforelse
+</div>
 @endsection
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const timerEl = document.querySelector('[data-shift-timer]');
+        if (timerEl) {
+            const start = timerEl.getAttribute('data-start');
+            if (start) {
+                const startDate = new Date(start);
+                const updateTimer = () => {
+                    const now = new Date();
+                    let diff = Math.max(0, Math.floor((now.getTime() - startDate.getTime()) / 1000));
+                    const hours = Math.floor(diff / 3600);
+                    diff -= hours * 3600;
+                    const minutes = Math.floor(diff / 60);
+                    const seconds = diff - minutes * 60;
+                    timerEl.textContent = String(hours).padStart(2, '0') + ':' + String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0');
+                };
+                updateTimer();
+                setInterval(updateTimer, 1000);
+            }
+        }
+
+        document.querySelectorAll('[data-fill-amount]').forEach(button => {
+            button.addEventListener('click', function () {
+                const targetId = this.getAttribute('data-target');
+                const amount = this.getAttribute('data-amount');
+                const input = document.getElementById(targetId);
+                if (input) {
+                    input.value = amount || '';
+                    input.focus();
+                }
+            });
+        });
+
+        document.querySelectorAll('form[data-attendance-form]').forEach(form => {
+            const submitButton = form.querySelector('button[type="submit"]');
+            form.addEventListener('submit', function () {
+                if (submitButton) {
+                    submitButton.disabled = true;
+                    submitButton.dataset.originalText = submitButton.textContent;
+                    submitButton.textContent = 'Отмечаем...';
+                }
+            });
+        });
+    });
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- move shift start and stop buttons from the global layout into the reception screen and show an active shift banner with timer details
- reorganize the reception dashboard to filter today’s sections, add search and pagination, and surface child attendance and payment status with quick actions
- introduce payment modals and inline helpers for shift timing, payment autofill, and one-click attendance locking

## Testing
- php artisan test *(fails: vendor dependencies not installed and Composer requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5caebb2e88326a2e409b09caef561