### PR TITLE
Fix Blade @php directives for compatibility

### DIFF
--- a/resources/views/reception/index.blade.php
+++ b/resources/views/reception/index.blade.php
@@ -23,8 +23,10 @@
             <div class="row g-4 align-items-center">
                 <div class="col-lg-7">
                     <h2 class="h4 mb-3">Управление сменой</h2>
-                    @php($settingStart = $shiftSetting ? substr($shiftSetting->shift_starts_at,0,5) : null)
-                    @php($settingEnd = $shiftSetting ? substr($shiftSetting->shift_ends_at,0,5) : null)
+                    @php
+                        $settingStart = $shiftSetting ? substr($shiftSetting->shift_starts_at, 0, 5) : null;
+                        $settingEnd = $shiftSetting ? substr($shiftSetting->shift_ends_at, 0, 5) : null;
+                    @endphp
                     @if($shiftSetting)
                         <div class="text-secondary small mb-2">
                             График: {{ $settingStart }} — {{ $settingEnd }} ·

--- a/resources/views/reception/settings.blade.php
+++ b/resources/views/reception/settings.blade.php
@@ -13,9 +13,11 @@
 @else
     <div class="d-flex flex-column gap-4">
         @foreach($receptionists as $receptionist)
-            @php($setting = $receptionist->receptionSetting)
-            @php($startValue = $setting?->shift_starts_at ? substr($setting->shift_starts_at,0,5) : '09:00')
-            @php($endValue = $setting?->shift_ends_at ? substr($setting->shift_ends_at,0,5) : '18:00')
+            @php
+                $setting = $receptionist->receptionSetting;
+                $startValue = $setting?->shift_starts_at ? substr($setting->shift_starts_at, 0, 5) : '09:00';
+                $endValue = $setting?->shift_ends_at ? substr($setting->shift_ends_at, 0, 5) : '18:00';
+            @endphp
             <div class="card shadow-sm border-0">
                 <div class="card-body p-4">
                     <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-3">

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -51,8 +51,10 @@
         <div class="card card-kpi shadow-sm border-0 h-100">
             <div class="card-body">
                 <div class="text-secondary small">Рабочие часы ресепшена</div>
-                @php($totalMinutes = $shiftTotals->sum('total_minutes'))
-                @php($totalHours = intdiv($totalMinutes, 60))
+                @php
+                    $totalMinutes = $shiftTotals->sum('total_minutes');
+                    $totalHours = intdiv($totalMinutes, 60);
+                @endphp
                 <div class="kpi">{{ $totalHours }}ч {{ $totalMinutes % 60 }}м</div>
                 <div class="text-secondary small mt-1">Смен: {{ $shiftTotals->sum('shifts_count') }}</div>
             </div>
@@ -151,8 +153,10 @@
                             <thead class="table-light"><tr><th>Сотрудник</th><th class="text-end">Смен</th><th class="text-end">Часы</th></tr></thead>
                             <tbody>
                             @foreach($shiftTotals as $row)
-                                @php($minutes = $row['total_minutes'])
-                                @php($hours = intdiv($minutes, 60))
+                                @php
+                                    $minutes = $row['total_minutes'];
+                                    $hours = intdiv($minutes, 60);
+                                @endphp
                                 <tr>
                                     <td>{{ $row['user']->name }}</td>
                                     <td class="text-end">{{ $row['shifts_count'] }}</td>

--- a/resources/views/sections/packages/_form.blade.php
+++ b/resources/views/sections/packages/_form.blade.php
@@ -2,7 +2,9 @@
 @if(isset($package))
     @method('PUT')
 @endif
-@php($isActiveValue = (string) old('is_active', isset($package) ? ($package->is_active ? '1' : '0') : '1'))
+@php
+    $isActiveValue = (string) old('is_active', isset($package) ? ($package->is_active ? '1' : '0') : '1');
+@endphp
 <div class="row g-3">
     <div class="col-md-6">
         <label class="form-label">Название</label>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -9,7 +9,9 @@
             <div class="col-md-4"><label class="form-label">Телефон</label><input name="phone" class="form-control" value="{{ old('phone',$user->phone) }}"></div>
             <div class="col-md-4"><label class="form-label">Новый пароль (если менять)</label><input type="password" name="password" class="form-control"></div>
             <div class="col-md-4"><label class="form-label">Повтор пароля</label><input type="password" name="password_confirmation" class="form-control"></div>
-            @php($role = $user->getRoleNames()->first())
+            @php
+                $role = $user->getRoleNames()->first();
+            @endphp
             <div class="col-md-4"><label class="form-label">Роль</label>
                 @if($role === \App\Models\User::ROLE_ADMIN)
                     <input type="hidden" name="role" value="Admin">


### PR DESCRIPTION
## Summary
- replace single-line `@php(...)` directives with standard `@php … @endphp` blocks across reception, reports, sections, and users views
- ensure shift and settings helpers are calculated inside PHP blocks for broader Blade compatibility

## Testing
- php artisan test *(fails: missing Composer dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5da87094c83268ec15c3b3cb35a7e