### PR TITLE
Restrict admin reception actions and add admin summary

### DIFF
--- a/app/Http/Controllers/ReceptionController.php
+++ b/app/Http/Controllers/ReceptionController.php
@@ -95,12 +95,18 @@ class ReceptionController extends Controller
             }
         }
 
-        $shiftSetting = $user && $user->hasRole(User::ROLE_RECEPTIONIST)
+        $canManage = $user && $user->hasRole(User::ROLE_RECEPTIONIST);
+
+        $shiftSetting = $canManage
             ? $this->shiftManager->getSetting($user)
             : null;
 
         $shiftActive = (bool) $shift;
-        $shiftBlockReason = $shiftActive ? null : 'Начните смену, чтобы отмечать посещения и принимать оплату.';
+        if ($canManage) {
+            $shiftBlockReason = $shiftActive ? null : 'Начните смену, чтобы отмечать посещения и принимать оплату.';
+        } else {
+            $shiftBlockReason = $shiftActive ? null : 'Рабочие действия доступны только ресепшионистам.';
+        }
 
         return view('reception.index', [
             'sectionCards' => $sectionCards,
@@ -113,6 +119,7 @@ class ReceptionController extends Controller
             'shiftSetting' => $shiftSetting,
             'shiftCanStop' => $shiftCanStop,
             'shiftStopLockedUntil' => $shiftStopLockedUntil,
+            'canManage' => $canManage,
         ]);
     }
 

--- a/app/Http/Controllers/ReceptionSummaryController.php
+++ b/app/Http/Controllers/ReceptionSummaryController.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Attendance;
+use App\Models\Payment;
+use App\Models\Shift;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class ReceptionSummaryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $period = $request->input('period');
+        $fromInput = $request->input('from');
+        $toInput = $request->input('to');
+
+        if (!$period && !$fromInput && !$toInput) {
+            $period = 'today';
+        }
+
+        $now = Carbon::now();
+        $defaultFrom = $now->copy()->startOfDay();
+        $defaultTo = $now->copy()->endOfDay();
+
+        if ($period === 'yesterday') {
+            $defaultFrom = $now->copy()->subDay()->startOfDay();
+            $defaultTo = $now->copy()->subDay()->endOfDay();
+        } elseif ($period === 'week') {
+            $defaultFrom = $now->copy()->subDays(6)->startOfDay();
+            $defaultTo = $now->copy()->endOfDay();
+        }
+
+        $from = $fromInput ? Carbon::parse($fromInput)->startOfDay() : $defaultFrom->copy();
+        $to = $toInput ? Carbon::parse($toInput)->endOfDay() : $defaultTo->copy();
+
+        if ($from->greaterThan($to)) {
+            [$from, $to] = [$to->copy()->startOfDay(), $from->copy()->endOfDay()];
+        }
+
+        $attendanceQuery = Attendance::with(['child', 'section', 'marker'])
+            ->whereBetween('attended_on', [$from->toDateString(), $to->toDateString()])
+            ->whereHas('marker', function ($query) {
+                $query->role(User::ROLE_RECEPTIONIST);
+            })
+            ->orderByDesc('attended_at');
+
+        $attendances = $attendanceQuery->get();
+
+        $totalVisits = $attendances->count();
+        $uniqueChildren = $attendances->pluck('child_id')->unique()->count();
+
+        $sectionsSummary = $attendances
+            ->groupBy('section_id')
+            ->map(function ($items) {
+                $section = $items->first()->section;
+                return [
+                    'section' => $section,
+                    'visits' => $items->count(),
+                    'unique_children' => $items->pluck('child_id')->unique()->count(),
+                ];
+            })
+            ->sortByDesc('visits')
+            ->values();
+
+        $payments = Payment::with(['child', 'enrollment.section', 'user'])
+            ->whereBetween('paid_at', [$from, $to])
+            ->whereHas('user', function ($query) {
+                $query->role(User::ROLE_RECEPTIONIST);
+            })
+            ->orderByDesc('paid_at')
+            ->get();
+
+        $paymentsTotal = $payments->sum('amount');
+
+        $rangeStart = $from->copy();
+        $rangeEnd = $to->copy();
+
+        $shiftRecords = Shift::with('user')
+            ->whereHas('user', function ($query) {
+                $query->role(User::ROLE_RECEPTIONIST);
+            })
+            ->where('started_at', '<=', $rangeEnd)
+            ->where(function ($query) use ($rangeStart) {
+                $query->whereNull('ended_at')->orWhere('ended_at', '>=', $rangeStart);
+            })
+            ->orderBy('started_at')
+            ->get()
+            ->map(function (Shift $shift) use ($rangeStart, $rangeEnd) {
+                $shiftStart = $shift->started_at->copy();
+                $shiftEnd = $shift->ended_at
+                    ?? ($shift->scheduled_end_at && $shift->scheduled_end_at->lessThan(now())
+                        ? $shift->scheduled_end_at->copy()
+                        : now());
+
+                if ($shiftEnd->greaterThan($rangeEnd)) {
+                    $shiftEnd = $rangeEnd->copy();
+                }
+                if ($shiftStart->lessThan($rangeStart)) {
+                    $shiftStart = $rangeStart->copy();
+                }
+
+                $minutes = $shiftEnd->greaterThan($shiftStart)
+                    ? $shiftStart->diffInMinutes($shiftEnd)
+                    : 0;
+
+                $shift->summary_minutes = $minutes;
+                $shift->summary_duration_human = sprintf('%02d:%02d', intdiv($minutes, 60), $minutes % 60);
+
+                return $shift;
+            });
+
+        $shiftTotals = $shiftRecords
+            ->groupBy('user_id')
+            ->map(function ($items) {
+                $minutes = $items->sum(fn (Shift $shift) => $shift->summary_minutes);
+                $user = $items->first()->user;
+
+                return [
+                    'user' => $user,
+                    'total_minutes' => $minutes,
+                    'total_formatted' => sprintf('%02d:%02d', intdiv($minutes, 60), $minutes % 60),
+                    'shifts_count' => $items->count(),
+                ];
+            })
+            ->sortByDesc('total_minutes')
+            ->values();
+
+        $quickRanges = [
+            'today' => 'Сегодня',
+            'yesterday' => 'Вчера',
+            'week' => 'Последние 7 дней',
+        ];
+
+        return view('reception.summary', [
+            'from' => $from->toDateString(),
+            'to' => $to->toDateString(),
+            'period' => $period,
+            'quickRanges' => $quickRanges,
+            'totalVisits' => $totalVisits,
+            'uniqueChildren' => $uniqueChildren,
+            'sectionsSummary' => $sectionsSummary,
+            'attendances' => $attendances,
+            'payments' => $payments,
+            'paymentsTotal' => $paymentsTotal,
+            'shiftTotals' => $shiftTotals,
+            'shiftRecords' => $shiftRecords,
+        ]);
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -26,6 +26,7 @@
                 <li class="nav-item"><a class="nav-link" href="/sections">Секции</a></li>
                 <li class="nav-item"><a class="nav-link" href="/packages">Пакеты</a></li>
                 @role('Admin')
+                <li class="nav-item"><a class="nav-link" href="{{ route('reception.summary') }}">Сводка ресепшена</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ route('reception.settings') }}">Настройки ресепшена</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ route('reports.index') }}">Отчёты</a></li>
                 <li class="nav-item"><a class="nav-link" href="/rooms">Комнаты</a></li>

--- a/resources/views/reception/summary.blade.php
+++ b/resources/views/reception/summary.blade.php
@@ -1,0 +1,232 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="d-flex flex-column gap-4">
+    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-end">
+        <div>
+            <h1 class="h3 mb-1">Сводка ресепшена</h1>
+            <p class="text-secondary mb-0">Обзор посещений, оплат и работы ресепшионистов за выбранный период.</p>
+        </div>
+        <form class="ms-lg-auto w-100 w-lg-auto" method="GET" action="{{ route('reception.summary') }}">
+            <div class="row g-2">
+                <div class="col-6 col-lg-auto">
+                    <label class="form-label small text-secondary">С</label>
+                    <input type="date" name="from" value="{{ $from }}" class="form-control">
+                </div>
+                <div class="col-6 col-lg-auto">
+                    <label class="form-label small text-secondary">По</label>
+                    <input type="date" name="to" value="{{ $to }}" class="form-control">
+                </div>
+                <div class="col-12 col-lg-auto d-flex align-items-end gap-2">
+                    <button class="btn btn-primary" type="submit">Показать</button>
+                    @if(request()->hasAny(['from','to','period']))
+                        <a class="btn btn-outline-secondary" href="{{ route('reception.summary') }}">Сбросить</a>
+                    @endif
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="d-flex flex-wrap gap-2">
+        @foreach($quickRanges as $key => $label)
+            @php
+                $query = array_merge(request()->query(), ['period' => $key]);
+                unset($query['from'], $query['to']);
+            @endphp
+            <a href="{{ route('reception.summary', $query) }}" class="btn btn-sm {{ $period === $key ? 'btn-primary' : 'btn-outline-primary' }}">{{ $label }}</a>
+        @endforeach
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-4">
+            <div class="card shadow-sm border-0 card-kpi">
+                <div class="card-body">
+                    <div class="text-secondary small text-uppercase">Всего посещений</div>
+                    <div class="kpi mt-2">{{ $totalVisits }}</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card shadow-sm border-0 card-kpi">
+                <div class="card-body">
+                    <div class="text-secondary small text-uppercase">Уникальных детей</div>
+                    <div class="kpi mt-2">{{ $uniqueChildren }}</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card shadow-sm border-0 card-kpi">
+                <div class="card-body">
+                    <div class="text-secondary small text-uppercase">Оплаты</div>
+                    <div class="kpi mt-2">{{ number_format((float)$paymentsTotal, 2, ',', ' ') }} ₽</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <h2 class="h5 mb-3">Секции и посещения</h2>
+            @if($sectionsSummary->isEmpty())
+                <p class="text-secondary mb-0">За выбранный период посещений не было.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0">
+                        <thead>
+                        <tr>
+                            <th>Секция</th>
+                            <th>Посещений</th>
+                            <th>Детей</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($sectionsSummary as $summary)
+                            <tr>
+                                <td>{{ $summary['section']?->name ?? '—' }}</td>
+                                <td>{{ $summary['visits'] }}</td>
+                                <td>{{ $summary['unique_children'] }}</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-body p-4">
+                    <h2 class="h5 mb-3">Приходы детей</h2>
+                    @if($attendances->isEmpty())
+                        <p class="text-secondary mb-0">Нет отмеченных посещений.</p>
+                    @else
+                        <div class="table-responsive">
+                            <table class="table align-middle mb-0">
+                                <thead>
+                                <tr>
+                                    <th>Время</th>
+                                    <th>Ребёнок</th>
+                                    <th>Секция</th>
+                                    <th>Отметил</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach($attendances as $attendance)
+                                    <tr>
+                                        <td>{{ optional($attendance->attended_at)->format('d.m.Y H:i') ?? $attendance->attended_on->format('d.m.Y') }}</td>
+                                        <td>{{ $attendance->child?->full_name ?? '—' }}</td>
+                                        <td>{{ $attendance->section?->name ?? '—' }}</td>
+                                        <td>{{ $attendance->marker?->name ?? '—' }}</td>
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-body p-4">
+                    <h2 class="h5 mb-3">Принятые оплаты</h2>
+                    @if($payments->isEmpty())
+                        <p class="text-secondary mb-0">Оплат за период не зафиксировано.</p>
+                    @else
+                        <div class="table-responsive">
+                            <table class="table align-middle mb-0">
+                                <thead>
+                                <tr>
+                                    <th>Время</th>
+                                    <th>Ребёнок</th>
+                                    <th>Секция</th>
+                                    <th>Сумма</th>
+                                    <th>Принял</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach($payments as $payment)
+                                    <tr>
+                                        <td>{{ optional($payment->paid_at)->format('d.m.Y H:i') }}</td>
+                                        <td>{{ $payment->child?->full_name ?? '—' }}</td>
+                                        <td>{{ $payment->enrollment?->section?->name ?? '—' }}</td>
+                                        <td>{{ number_format((float)$payment->amount, 2, ',', ' ') }} ₽</td>
+                                        <td>{{ $payment->user?->name ?? '—' }}</td>
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <h2 class="h5 mb-3">Рабочее время ресепшионистов</h2>
+            @if($shiftTotals->isEmpty())
+                <p class="text-secondary mb-0">Смены в выбранный период отсутствуют.</p>
+            @else
+                <div class="table-responsive mb-4">
+                    <table class="table align-middle mb-0">
+                        <thead>
+                        <tr>
+                            <th>Ресепшионист</th>
+                            <th>Смен</th>
+                            <th>Общее время</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($shiftTotals as $total)
+                            <tr>
+                                <td>{{ $total['user']?->name ?? '—' }}</td>
+                                <td>{{ $total['shifts_count'] }}</td>
+                                <td>{{ $total['total_formatted'] }}</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+
+                <h3 class="h6 mb-3">Подробности смен</h3>
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0">
+                        <thead>
+                        <tr>
+                            <th>Ресепшионист</th>
+                            <th>Начало</th>
+                            <th>Завершение</th>
+                            <th>Длительность</th>
+                            <th>Закрытие</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($shiftRecords as $shift)
+                            <tr>
+                                <td>{{ $shift->user?->name ?? '—' }}</td>
+                                <td>{{ optional($shift->started_at)->format('d.m.Y H:i') }}</td>
+                                <td>
+                                    @if($shift->ended_at)
+                                        {{ $shift->ended_at->format('d.m.Y H:i') }}
+                                    @elseif($shift->scheduled_end_at && $shift->scheduled_end_at->lessThan(now()))
+                                        {{ $shift->scheduled_end_at->format('d.m.Y H:i') }} <span class="badge bg-secondary ms-1">Авто</span>
+                                    @else
+                                        —
+                                    @endif
+                                </td>
+                                <td>{{ $shift->summary_duration_human }}</td>
+                                <td>{{ $shift->closed_automatically ? 'Автоматически' : ($shift->ended_at ? 'Вручную' : 'Открыта') }}</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\{AttendanceController, PaymentController, ShiftController, EnrollmentController, SectionController, ChildController, ReceptionController, RoomController, SectionPackageController, ReceptionSettingController, ReportController};
+use App\Http\Controllers\{AttendanceController, PaymentController, ShiftController, EnrollmentController, SectionController, ChildController, ReceptionController, RoomController, SectionPackageController, ReceptionSettingController, ReportController, ReceptionSummaryController};
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\AccountController;
 
@@ -17,6 +17,7 @@ Route::get('/', function(){ return view('welcome'); });
 
 Route::middleware(['auth','role:Admin'])->group(function(){
     Route::resource('users', UserController::class)->except(['show']);
+    Route::get('/reception/summary', [ReceptionSummaryController::class,'index'])->name('reception.summary');
     Route::get('/reception/settings', [ReceptionSettingController::class,'index'])->name('reception.settings');
     Route::put('/reception/settings/{user}', [ReceptionSettingController::class,'update'])->name('reception.settings.update');
     Route::get('/reports', [ReportController::class,'index'])->name('reports.index');
@@ -32,16 +33,16 @@ Route::middleware(['auth'])->group(function(){
 
 
 // Смены ресепшена
-    Route::post('/shift/start',[ShiftController::class,'start'])->name('shift.start');
-    Route::post('/shift/stop',[ShiftController::class,'stop'])->name('shift.stop');
+    Route::post('/shift/start',[ShiftController::class,'start'])->name('shift.start')->middleware('role:Receptionist');
+    Route::post('/shift/stop',[ShiftController::class,'stop'])->name('shift.stop')->middleware('role:Receptionist');
 
 
 // Посещения
-    Route::post('/attendances',[AttendanceController::class,'store'])->name('attendances.store')->middleware('shift.active');
+    Route::post('/attendances',[AttendanceController::class,'store'])->name('attendances.store')->middleware(['shift.active','role:Receptionist']);
 
 
 // Платежи
-    Route::post('/payments',[PaymentController::class,'store'])->name('payments.store')->middleware('shift.active');
+    Route::post('/payments',[PaymentController::class,'store'])->name('payments.store')->middleware(['shift.active','role:Receptionist']);
 
 
 // Enrollment: прикрепление ребёнка к секции/пакету
@@ -67,8 +68,8 @@ Route::middleware(['auth'])->group(function(){
         Route::post('children/{child}/deactivate',[ChildController::class,'deactivate'])->name('children.deactivate');
         Route::post('children/{child}/activate',[ChildController::class,'activate'])->name('children.activate');
         Route::get('/reception',[ReceptionController::class,'index'])->name('reception.index');
-        Route::post('/reception/mark',[ReceptionController::class,'mark'])->name('reception.mark')->middleware('shift.active');
-        Route::post('/reception/renew',[ReceptionController::class,'renew'])->name('reception.renew');
+        Route::post('/reception/mark',[ReceptionController::class,'mark'])->name('reception.mark')->middleware(['shift.active','role:Receptionist']);
+        Route::post('/reception/renew',[ReceptionController::class,'renew'])->name('reception.renew')->middleware('role:Receptionist');
     });
 });
 


### PR DESCRIPTION
## Summary
- Disable reception shift, attendance, and payment actions for administrators while keeping the interface visible by gating the controller logic and templates behind a receptionist capability flag.
- Tighten routing so only receptionists can start or stop shifts, record attendance, accept payments, or renew enrollments, and surface the new admin summary link in the navigation.
- Add an administrator reception summary controller and dashboard that aggregates visits, payments, and shift activity for receptionist users across configurable periods.

## Testing
- ❌ `php artisan test` *(fails: missing vendor dependencies because composer install requires a GitHub token in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d5dcdffd488326836c45c0b18841a8