### PR TITLE
Fix shift duration calculation in seeder

### DIFF
--- a/database/seeders/ComprehensiveDemoSeeder.php
+++ b/database/seeders/ComprehensiveDemoSeeder.php
@@ -213,7 +213,7 @@ class ComprehensiveDemoSeeder extends Seeder
                 if ($endedAt->lessThan($startedAt)) {
                     $endedAt = (clone $scheduledEnd);
                 }
-                $duration = $endedAt->diffInMinutes($startedAt);
+                $duration = max($startedAt->diffInMinutes($endedAt, false), 0);
                 $closedAutomatically = rand(0, 4) === 0;
 
                 $shift = Shift::create([


### PR DESCRIPTION
## Summary
- ensure generated demo shift durations are never negative by clamping the calculated minutes to zero

## Testing
- php artisan db:seed --class=ComprehensiveDemoSeeder *(fails: missing vendor directory prior to installing dependencies)*
- composer install *(fails: requires GitHub token for package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e74d5e9c8326aee26ea7139b313f