### PR TITLE
Enhance dashboard with analytics and scheduling visuals

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Attendance;
+use App\Models\Child;
+use App\Models\Enrollment;
+use App\Models\Payment;
+use App\Models\Section;
+use Carbon\Carbon;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $now = now();
+        $startOfMonth = $now->copy()->startOfMonth();
+        $prevMonthStart = $startOfMonth->copy()->subMonth();
+        $prevMonthEnd = $startOfMonth->copy()->subDay();
+        $startOfWeek = $now->copy()->startOfWeek();
+        $prevWeekStart = $startOfWeek->copy()->subWeek();
+        $prevWeekEnd = $prevWeekStart->copy()->endOfWeek();
+        $monthShort = [1 => 'Янв', 2 => 'Фев', 3 => 'Мар', 4 => 'Апр', 5 => 'Май', 6 => 'Июн', 7 => 'Июл', 8 => 'Авг', 9 => 'Сен', 10 => 'Окт', 11 => 'Ноя', 12 => 'Дек'];
+        $weekdayNames = [1 => 'Понедельник', 2 => 'Вторник', 3 => 'Среда', 4 => 'Четверг', 5 => 'Пятница', 6 => 'Суббота', 7 => 'Воскресенье'];
+
+        $totalChildren = Child::count();
+        $activeChildren = Child::active()->count();
+        $newChildrenThisMonth = Child::whereBetween('created_at', [$startOfMonth, $now])->count();
+        $newChildrenLastMonth = Child::whereBetween('created_at', [$prevMonthStart, $prevMonthEnd])->count();
+
+        $sectionsCount = Section::count();
+        $activeSections = Section::where('is_active', true)->count();
+        $subSectionsCount = Section::whereNotNull('parent_id')->count();
+        $rootSectionsCount = $sectionsCount - $subSectionsCount;
+
+        $activeEnrollments = Enrollment::where('status', '!=', 'expired')->count();
+        $outstandingBalance = Enrollment::whereIn('status', ['pending', 'partial'])->get(['price', 'total_paid'])
+            ->sum(function (Enrollment $enrollment) {
+                $remaining = (float) $enrollment->price - (float) $enrollment->total_paid;
+                return $remaining > 0 ? $remaining : 0;
+            });
+
+        $paymentsThisMonth = (float) Payment::whereBetween('paid_at', [$startOfMonth, $now])->sum('amount');
+        $paymentsLastMonth = (float) Payment::whereBetween('paid_at', [$prevMonthStart, $prevMonthEnd])->sum('amount');
+        $avgPaymentThisMonth = (float) Payment::whereBetween('paid_at', [$startOfMonth, $now])->avg('amount');
+
+        $attendanceThisWeek = Attendance::whereBetween('attended_on', [$startOfWeek, $now->copy()->endOfWeek()])->count();
+        $attendanceLastWeek = Attendance::whereBetween('attended_on', [$prevWeekStart, $prevWeekEnd])->count();
+
+        $recentPayments = Payment::with('child')->orderByDesc('paid_at')->limit(6)->get();
+
+        $expiringEnrollments = Enrollment::with(['child', 'section'])
+            ->whereNotNull('expires_at')
+            ->whereBetween('expires_at', [$now->copy()->startOfDay(), $now->copy()->addDays(14)->endOfDay()])
+            ->orderBy('expires_at')
+            ->limit(10)
+            ->get();
+        $today = $now->copy()->startOfDay();
+        $expiringEnrollments->each(function (Enrollment $enrollment) use ($today) {
+            $enrollment->days_left = $today->diffInDays($enrollment->expires_at, false);
+        });
+
+        $monthsRange = collect(range(0, 11))->map(function (int $index) use ($now) {
+            return $now->copy()->subMonths(11 - $index)->startOfMonth();
+        });
+        $childGrowthRaw = Child::where('created_at', '>=', $monthsRange->first())
+            ->get(['id', 'created_at'])
+            ->groupBy(function (Child $child) {
+                return $child->created_at->format('Y-m');
+            })
+            ->map->count();
+        $childrenGrowthLabels = $monthsRange->map(function (Carbon $month) use ($monthShort) {
+            return ($monthShort[$month->month] ?? $month->format('M')) . ' ' . $month->format('Y');
+        });
+        $childrenGrowthValues = $monthsRange->map(function (Carbon $month) use ($childGrowthRaw) {
+            return (int) ($childGrowthRaw[$month->format('Y-m')] ?? 0);
+        });
+
+        $paymentsRaw = Payment::where('paid_at', '>=', $monthsRange->first())
+            ->get(['amount', 'paid_at'])
+            ->groupBy(function (Payment $payment) {
+                return $payment->paid_at->format('Y-m');
+            })
+            ->map(function ($group) {
+                return $group->sum(function (Payment $payment) {
+                    return (float) $payment->amount;
+                });
+            });
+        $paymentsTrendValues = $monthsRange->map(function (Carbon $month) use ($paymentsRaw) {
+            return round($paymentsRaw[$month->format('Y-m')] ?? 0, 2);
+        });
+
+        $attendanceWeeksRange = collect(range(0, 7))->map(function (int $index) use ($now) {
+            return $now->copy()->subWeeks(7 - $index)->startOfWeek();
+        });
+        $attendanceRaw = Attendance::where('attended_on', '>=', $attendanceWeeksRange->first())
+            ->get(['attended_on'])
+            ->groupBy(function (Attendance $attendance) {
+                return $attendance->attended_on->copy()->startOfWeek()->format('Y-m-d');
+            })
+            ->map->count();
+        $attendanceLabels = $attendanceWeeksRange->map(function (Carbon $week) {
+            return 'Нед ' . $week->format('W');
+        });
+        $attendanceValues = $attendanceWeeksRange->map(function (Carbon $week) use ($attendanceRaw) {
+            return (int) ($attendanceRaw[$week->format('Y-m-d')] ?? 0);
+        });
+
+        $statusBreakdown = Enrollment::select('status')->selectRaw('COUNT(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        $sections = Section::withCount(['enrollments as active_enrollments_count' => function ($query) {
+            $query->where('status', '!=', 'expired');
+        }])->where('is_active', true)->get();
+
+        $calendarDays = collect(range(0, 13))->map(function (int $offset) use ($sections, $weekdayNames, $now) {
+            $date = $now->copy()->startOfDay()->addDays($offset);
+            $sectionsForDay = $sections->filter(function (Section $section) use ($date) {
+                return $this->sectionRunsOnDate($section, $date);
+            })->map(function (Section $section) {
+                return [
+                    'id' => $section->id,
+                    'name' => $section->name,
+                    'active_enrollments' => (int) $section->active_enrollments_count,
+                ];
+            })->values();
+
+            $totalChildren = $sectionsForDay->sum('active_enrollments');
+
+            return [
+                'date' => $date,
+                'weekday' => $weekdayNames[$date->isoWeekday()] ?? $date->format('l'),
+                'sections' => $sectionsForDay->toArray(),
+                'total_children' => $totalChildren,
+            ];
+        })->values();
+
+        $sectionsToday = $calendarDays->first();
+        $sectionsTomorrow = $calendarDays->get(1);
+
+        $topSections = $sections->sortByDesc('active_enrollments_count')->take(5);
+
+        return view('dashboard', [
+            'metrics' => [
+                'totalChildren' => $totalChildren,
+                'activeChildren' => $activeChildren,
+                'newChildrenThisMonth' => $newChildrenThisMonth,
+                'newChildrenLastMonth' => $newChildrenLastMonth,
+                'sectionsCount' => $sectionsCount,
+                'activeSections' => $activeSections,
+                'rootSectionsCount' => $rootSectionsCount,
+                'subSectionsCount' => $subSectionsCount,
+                'activeEnrollments' => $activeEnrollments,
+                'paymentsThisMonth' => $paymentsThisMonth,
+                'paymentsLastMonth' => $paymentsLastMonth,
+                'avgPaymentThisMonth' => $avgPaymentThisMonth,
+                'attendanceThisWeek' => $attendanceThisWeek,
+                'attendanceLastWeek' => $attendanceLastWeek,
+                'outstandingBalance' => $outstandingBalance,
+            ],
+            'childrenGrowthChart' => [
+                'labels' => $childrenGrowthLabels,
+                'values' => $childrenGrowthValues,
+            ],
+            'paymentsChart' => [
+                'labels' => $childrenGrowthLabels,
+                'values' => $paymentsTrendValues,
+            ],
+            'attendanceChart' => [
+                'labels' => $attendanceLabels,
+                'values' => $attendanceValues,
+            ],
+            'statusBreakdown' => [
+                'labels' => $statusBreakdown->keys()->values(),
+                'values' => $statusBreakdown->values(),
+            ],
+            'topSections' => $topSections,
+            'expiringEnrollments' => $expiringEnrollments,
+            'recentPayments' => $recentPayments,
+            'calendarDays' => $calendarDays,
+            'sectionsToday' => $sectionsToday,
+            'sectionsTomorrow' => $sectionsTomorrow,
+        ]);
+    }
+
+    protected function sectionRunsOnDate(Section $section, Carbon $date): bool
+    {
+        if (empty($section->schedule_type)) {
+            return false;
+        }
+
+        if ($section->schedule_type === 'weekly') {
+            $weekdays = $section->weekdays ?? [];
+            return in_array($date->isoWeekday(), $weekdays, true);
+        }
+
+        if ($section->schedule_type === 'monthly') {
+            $monthDays = $section->month_days ?? [];
+            return in_array($date->day, $monthDays, true);
+        }
+
+        return false;
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,23 +1,462 @@
 @extends('layouts.app')
+
 @section('content')
-    <div class="row g-3">
-        <div class="col-md-4">
-            <div class="card card-kpi"><div class="card-body">
-                    <div class="text-secondary">Всего детей</div>
-                    <div class="kpi">{{ \App\Models\Child::count() }}</div>
-                </div></div>
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
+        <div>
+            <h1 class="h3 mb-1">Дашборд</h1>
+            <p class="text-secondary mb-0">Ключевые показатели развития клуба, динамика оплат и расписание секций.</p>
         </div>
-        <div class="col-md-4">
-            <div class="card card-kpi"><div class="card-body">
-                    <div class="text-secondary">Секции/подсекции</div>
-                    <div class="kpi">{{ \App\Models\Section::count() }}</div>
-                </div></div>
+        <div class="d-flex flex-wrap gap-2">
+            <a class="btn btn-primary" href="{{ route('reception.index') }}">Перейти на ресепшен</a>
+            @role('Admin')
+                <a class="btn btn-outline-secondary" href="{{ route('sections.index') }}">Все секции</a>
+            @endrole
+            <a class="btn btn-outline-secondary" href="{{ route('children.index') }}">Все дети</a>
         </div>
-        <div class="col-md-4">
-            <div class="card card-kpi"><div class="card-body">
-                    <div class="text-secondary">Активные пакеты</div>
-                    <div class="kpi">{{ \App\Models\Enrollment::where('status','!=','expired')->count() }}</div>
-                </div></div>
+    </div>
+
+    @php
+        $metrics = $metrics ?? [];
+        $childGrowthDiff = ($metrics['newChildrenThisMonth'] ?? 0) - ($metrics['newChildrenLastMonth'] ?? 0);
+        $paymentsDelta = ($metrics['paymentsThisMonth'] ?? 0) - ($metrics['paymentsLastMonth'] ?? 0);
+        $paymentsPercent = ($metrics['paymentsLastMonth'] ?? 0) > 0
+            ? round($paymentsDelta / max($metrics['paymentsLastMonth'], 1) * 100, 1)
+            : null;
+        $attendanceDiff = ($metrics['attendanceThisWeek'] ?? 0) - ($metrics['attendanceLastWeek'] ?? 0);
+        $formatMoney = fn ($value, $decimals = 0) => number_format((float) $value, $decimals, ',', ' ');
+        $statusLabels = [
+            'pending' => 'Ожидает оплаты',
+            'partial' => 'Частичная оплата',
+            'paid' => 'Оплачено',
+            'expired' => 'Истёк срок',
+        ];
+    @endphp
+
+    <div class="row g-3 mb-4">
+        <div class="col-12 col-sm-6 col-lg-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Всего детей</div>
+                    <div class="display-6 fw-bold">{{ $metrics['totalChildren'] ?? 0 }}</div>
+                    <div class="text-success small">Активных: {{ $metrics['activeChildren'] ?? 0 }}</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Новые дети (месяц)</div>
+                    <div class="display-6 fw-bold">{{ $metrics['newChildrenThisMonth'] ?? 0 }}</div>
+                    <div class="small {{ $childGrowthDiff >= 0 ? 'text-success' : 'text-danger' }}">
+                        {{ $childGrowthDiff >= 0 ? '+' : '' }}{{ $childGrowthDiff }} vs прошлый месяц
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Оплаты за месяц</div>
+                    <div class="display-6 fw-bold">{{ $formatMoney($metrics['paymentsThisMonth'] ?? 0, 0) }} ₽</div>
+                    <div class="small {{ $paymentsDelta >= 0 ? 'text-success' : 'text-danger' }}">
+                        {{ $paymentsDelta >= 0 ? '+' : '' }}{{ $formatMoney($paymentsDelta, 0) }} ₽
+                        @if(!is_null($paymentsPercent))
+                            ({{ $paymentsPercent >= 0 ? '+' : '' }}{{ $paymentsPercent }}%)
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Средний чек</div>
+                    <div class="display-6 fw-bold">{{ $formatMoney($metrics['avgPaymentThisMonth'] ?? 0, 0) }} ₽</div>
+                    <div class="text-secondary small">по проведённым оплатам этого месяца</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4">
+        <div class="col-12 col-md-6 col-xl-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Активные пакеты</div>
+                    <div class="display-6 fw-bold">{{ $metrics['activeEnrollments'] ?? 0 }}</div>
+                    <div class="text-secondary small">Ожидаемые поступления: {{ $formatMoney($metrics['outstandingBalance'] ?? 0, 0) }} ₽</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-md-6 col-xl-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Секции и подсекции</div>
+                    <div class="display-6 fw-bold">{{ $metrics['sectionsCount'] ?? 0 }}</div>
+                    <div class="text-secondary small">Основные: {{ $metrics['rootSectionsCount'] ?? 0 }}, Подсекции: {{ $metrics['subSectionsCount'] ?? 0 }}</div>
+                    @role('Admin')
+                        <a class="btn btn-sm btn-link px-0" href="{{ route('sections.index') }}">Управлять</a>
+                    @endrole
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-md-6 col-xl-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Расписание сегодня</div>
+                    <div class="display-6 fw-bold">{{ $sectionsToday['total_children'] ?? 0 }}</div>
+                    <div class="text-secondary small">детей в {{ isset($sectionsToday['sections']) ? count($sectionsToday['sections']) : 0 }} секциях</div>
+                    @if(!empty($sectionsToday['sections']))
+                        <div class="d-flex flex-wrap gap-1 mt-2">
+                            @foreach($sectionsToday['sections'] as $section)
+                                <a class="badge rounded-pill text-bg-light" href="{{ route('sections.members.index', ['section' => $section['id']]) }}">{{ $section['name'] }}</a>
+                            @endforeach
+                        </div>
+                    @else
+                        <div class="text-secondary small">Нет занятий</div>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-md-6 col-xl-3">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="text-secondary small">Расписание завтра</div>
+                    <div class="display-6 fw-bold">{{ $sectionsTomorrow['total_children'] ?? 0 }}</div>
+                    <div class="text-secondary small">детей в {{ isset($sectionsTomorrow['sections']) ? count($sectionsTomorrow['sections']) : 0 }} секциях</div>
+                    @if(!empty($sectionsTomorrow['sections']))
+                        <div class="d-flex flex-wrap gap-1 mt-2">
+                            @foreach($sectionsTomorrow['sections'] as $section)
+                                <a class="badge rounded-pill text-bg-light" href="{{ route('sections.members.index', ['section' => $section['id']]) }}">{{ $section['name'] }}</a>
+                            @endforeach
+                        </div>
+                    @else
+                        <div class="text-secondary small">Нет занятий</div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4">
+        <div class="col-12 col-xl-6">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h2 class="h5 mb-0">Рост числа детей</h2>
+                        <span class="text-secondary small">12 месяцев</span>
+                    </div>
+                    <canvas id="childrenGrowthChart" height="220"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-6">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h2 class="h5 mb-0">Динамика оплат</h2>
+                        <span class="text-secondary small">12 месяцев</span>
+                    </div>
+                    <canvas id="paymentsChart" height="220"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4">
+        <div class="col-12 col-xl-4">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <h2 class="h5 mb-3">Статусы пакетов</h2>
+                    <canvas id="enrollmentStatusChart" height="220"></canvas>
+                    <div class="d-flex flex-wrap gap-3 mt-3">
+                        @foreach($statusBreakdown['labels'] as $index => $label)
+                            @php $labelText = $statusLabels[$label] ?? ucfirst($label); @endphp
+                            <div class="small"><span class="legend-dot me-1" data-color-index="{{ $index }}"></span>{{ $labelText }} — {{ $statusBreakdown['values'][$index] }}</div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-4">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h2 class="h5 mb-0">Посещения по неделям</h2>
+                        <span class="text-secondary small">{{ $attendanceDiff >= 0 ? '+' : '' }}{{ $attendanceDiff }} vs прошлая неделя</span>
+                    </div>
+                    <canvas id="attendanceChart" height="220"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-4">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <h2 class="h5 mb-3">Популярные секции</h2>
+                    <ol class="list-group list-group-numbered list-group-flush">
+                        @forelse($topSections as $section)
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                <div>
+                                    <div class="fw-semibold">{{ $section->name }}</div>
+                                    <div class="text-secondary small">Активных детей: {{ $section->active_enrollments_count }}</div>
+                                </div>
+                                <a class="btn btn-sm btn-outline-primary" href="{{ route('sections.members.index', ['section' => $section->id]) }}">Состав</a>
+                            </li>
+                        @empty
+                            <li class="list-group-item text-secondary">Нет данных</li>
+                        @endforelse
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4">
+        <div class="col-12 col-xl-6">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h2 class="h5 mb-0">Сроки действия пакетов</h2>
+                        @role('Admin')
+                            <a class="btn btn-sm btn-outline-secondary" href="{{ route('reports.index') }}">Отчёт</a>
+                        @endrole
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Ребёнок</th>
+                                    <th>Секция</th>
+                                    <th>Истекает</th>
+                                    <th class="text-end">Осталось</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($expiringEnrollments as $enrollment)
+                                    <tr>
+                                        <td>{{ $enrollment->child->full_name ?? $enrollment->child->last_name }}</td>
+                                        <td>{{ $enrollment->section->name ?? '—' }}</td>
+                                        <td>{{ optional($enrollment->expires_at)->format('d.m.Y') }}</td>
+                                        <td class="text-end">
+                                            @if(isset($enrollment->days_left) && $enrollment->days_left >= 0)
+                                                {{ $enrollment->days_left }} дн.
+                                            @else
+                                                <span class="text-danger">просрочено</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="text-center text-secondary">Нет пакетов, истекающих в ближайшие 2 недели</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-6">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                    <h2 class="h5 mb-3">Последние оплаты</h2>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Дата</th>
+                                    <th>Ребёнок</th>
+                                    <th>Сумма</th>
+                                    <th>Метод</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($recentPayments as $payment)
+                                    <tr>
+                                        <td>{{ optional($payment->paid_at)->format('d.m.Y H:i') }}</td>
+                                        <td>{{ $payment->child->full_name ?? $payment->child->last_name ?? '—' }}</td>
+                                        <td>{{ $formatMoney($payment->amount ?? 0, 0) }} ₽</td>
+                                        <td>{{ $payment->method ?? '—' }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="text-center text-secondary">Ещё нет платежей</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="h5 mb-0">Календарь на 2 недели</h2>
+                <span class="text-secondary small">Наведи курсор на дату для подробностей</span>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Дата</th>
+                            <th>День недели</th>
+                            <th>Секции</th>
+                            <th class="text-end">Детей</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($calendarDays as $day)
+                            @php
+                                $sectionsForDay = collect($day['sections'] ?? []);
+                                $tooltip = $sectionsForDay->isEmpty()
+                                    ? 'Нет занятий'
+                                    : $sectionsForDay->map(fn ($section) => e($section['name']) . ' — ' . $section['active_enrollments'] . ' детей')->implode('<br>');
+                            @endphp
+                            <tr>
+                                <td>
+                                    <span class="badge text-bg-light" data-bs-toggle="tooltip" data-bs-html="true" title="{!! $tooltip !!}">
+                                        {{ $day['date']->format('d.m') }}
+                                    </span>
+                                </td>
+                                <td>{{ $day['weekday'] }}</td>
+                                <td>
+                                    @if($sectionsForDay->isEmpty())
+                                        <span class="text-secondary">—</span>
+                                    @else
+                                        <div class="d-flex flex-wrap gap-1">
+                                            @foreach($sectionsForDay as $section)
+                                                <a class="badge text-bg-secondary" href="{{ route('sections.members.index', ['section' => $section['id']]) }}" data-bs-toggle="tooltip" title="{{ $section['active_enrollments'] }} детей">
+                                                    {{ $section['name'] }}
+                                                </a>
+                                            @endforeach
+                                        </div>
+                                    @endif
+                                </td>
+                                <td class="text-end fw-semibold">{{ $day['total_children'] }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 @endsection
+
+@push('scripts')
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
+    <script>
+        const chartPalette = ['#4f46e5', '#22c55e', '#f97316', '#14b8a6', '#a855f7', '#ef4444'];
+
+        const childrenGrowthCtx = document.getElementById('childrenGrowthChart');
+        const paymentsCtx = document.getElementById('paymentsChart');
+        const attendanceCtx = document.getElementById('attendanceChart');
+        const statusCtx = document.getElementById('enrollmentStatusChart');
+
+        const childrenGrowthData = @json($childrenGrowthChart, JSON_UNESCAPED_UNICODE);
+        const paymentsData = @json($paymentsChart, JSON_UNESCAPED_UNICODE);
+        const attendanceData = @json($attendanceChart, JSON_UNESCAPED_UNICODE);
+        const statusData = @json($statusBreakdown, JSON_UNESCAPED_UNICODE);
+
+        if (childrenGrowthCtx) {
+            new Chart(childrenGrowthCtx, {
+                type: 'line',
+                data: {
+                    labels: childrenGrowthData.labels,
+                    datasets: [{
+                        label: 'Новых детей',
+                        data: childrenGrowthData.values,
+                        borderColor: chartPalette[0],
+                        backgroundColor: chartPalette[0] + '33',
+                        fill: true,
+                        tension: 0.3,
+                    }]
+                },
+                options: {
+                    plugins: {
+                        legend: { display: false }
+                    },
+                    scales: {
+                        y: { beginAtZero: true }
+                    }
+                }
+            });
+        }
+
+        if (paymentsCtx) {
+            new Chart(paymentsCtx, {
+                type: 'bar',
+                data: {
+                    labels: paymentsData.labels,
+                    datasets: [{
+                        label: 'Оплаты, ₽',
+                        data: paymentsData.values,
+                        backgroundColor: chartPalette[2]
+                    }]
+                },
+                options: {
+                    plugins: {
+                        legend: { display: false }
+                    },
+                    scales: {
+                        y: { beginAtZero: true }
+                    }
+                }
+            });
+        }
+
+        if (attendanceCtx) {
+            new Chart(attendanceCtx, {
+                type: 'line',
+                data: {
+                    labels: attendanceData.labels,
+                    datasets: [{
+                        label: 'Посещения',
+                        data: attendanceData.values,
+                        borderColor: chartPalette[1],
+                        backgroundColor: chartPalette[1] + '33',
+                        fill: true,
+                        tension: 0.3,
+                    }]
+                },
+                options: {
+                    plugins: { legend: { display: false } },
+                    scales: { y: { beginAtZero: true } }
+                }
+            });
+        }
+
+        if (statusCtx) {
+            new Chart(statusCtx, {
+                type: 'doughnut',
+                data: {
+                    labels: statusData.labels,
+                    datasets: [{
+                        data: statusData.values,
+                        backgroundColor: statusData.labels.map((_, index) => chartPalette[index % chartPalette.length])
+                    }]
+                },
+                options: {
+                    plugins: {
+                        legend: { display: false }
+                    }
+                }
+            });
+        }
+
+        document.querySelectorAll('.legend-dot').forEach((element) => {
+            const index = parseInt(element.getAttribute('data-color-index'), 10) || 0;
+            element.style.display = 'inline-block';
+            element.style.width = '0.75rem';
+            element.style.height = '0.75rem';
+            element.style.borderRadius = '999px';
+            element.style.backgroundColor = chartPalette[index % chartPalette.length];
+        });
+
+        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((tooltipTriggerEl) => {
+            new bootstrap.Tooltip(tooltipTriggerEl);
+        });
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\{AttendanceController, PaymentController, ShiftController, EnrollmentController, SectionController, ChildController, ReceptionController, RoomController, SectionPackageController, ReceptionSettingController, ReportController, ReceptionSummaryController};
+use App\Http\Controllers\{AttendanceController, PaymentController, ShiftController, EnrollmentController, SectionController, ChildController, ReceptionController, RoomController, SectionPackageController, ReceptionSettingController, ReportController, ReceptionSummaryController, DashboardController};
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\AccountController;
 
@@ -29,7 +29,7 @@ Route::middleware(['auth'])->group(function(){
 });
 
 Route::middleware(['auth'])->group(function(){
-    Route::view('/dashboard','dashboard')->name('dashboard');
+    Route::get('/dashboard',[DashboardController::class,'index'])->name('dashboard');
 
 
 // Смены ресепшена


### PR DESCRIPTION
## Summary
- add a dedicated DashboardController that aggregates KPIs, trends, and scheduling data for the dashboard
- redesign the dashboard blade to surface KPI cards, Chart.js visualizations, expiring packages, payments, and a tooltip-enabled calendar
- wire the /dashboard route to the new controller-driven view for authenticated users

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because composer install requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5eab088b483269b0939fe720acba1